### PR TITLE
Fix 64-bit build to actually build 64-bit code.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ environment:
 
     # 64-bit Studio 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015
+      GENERATOR: Visual Studio 14 2015 Win64
       CFG: Debug
       VSINSTALL: '"Microsoft Visual Studio 14.0"/VC'
       MSVC_PLATFORM: amd64
@@ -34,7 +34,7 @@ environment:
 
     # 64-bit Studio 2017
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: Visual Studio 15 2017
+      GENERATOR: Visual Studio 15 2017 Win64
       CFG: Debug
       VSINSTALL: '"Microsoft Visual Studio"/2017/Community/VC/Auxiliary/Build'
       MSVC_PLATFORM: amd64


### PR DESCRIPTION
Turns out that my appveyor stuff wasn't actually building 64-bit stuff, because I need to enable the 64-bit generator in cmake.